### PR TITLE
[DRAFT] Use host.docker.internal instead of local IP address in chrome.docker

### DIFF
--- a/packages/target-chrome-docker/src/create-chrome-docker-target.js
+++ b/packages/target-chrome-docker/src/create-chrome-docker-target.js
@@ -66,20 +66,19 @@ function createChromeDockerTarget({
   }
   runArgs.push('--add-host=host.docker.internal:host-gateway');
 
-  if (dockerUrl.indexOf('http://localhost') === 0 || isLocalFile) {
-    const ip = getLocalIPAddress();
+  if (isLocalFile) {
+    let ip = 'host.docker.internal';
+    staticServerPort = getRandomPort();
+    staticServerPath = dockerUrl.substr('file:'.length);
+    dockerUrl = `http://${ip}:${staticServerPort}`;
+  } else if(dockerUrl.indexOf('http://localhost') === 0) {
+    let ip = getLocalIPAddress();
     if (!ip) {
       throw new Error(
         'Unable to detect local IP address, try passing --host argument'
       );
     }
-    if (isLocalFile) {
-      staticServerPort = getRandomPort();
-      staticServerPath = dockerUrl.substr('file:'.length);
-      dockerUrl = `http://${ip}:${staticServerPort}`;
-    } else {
-      dockerUrl = dockerUrl.replace('localhost', ip);
-    }
+    dockerUrl = dockerUrl.replace('localhost', ip);
   }
 
   async function getIsImageDownloaded(imageName) {


### PR DESCRIPTION
Resolves https://github.com/oblador/loki/issues/473

Fixes an issue where the Chrome docker container cannot access Storybook running on the host machine via IP address, instead using the Docker `host.docker.internal` DNS entry to get access to it.